### PR TITLE
Add Dockerfile.build to use a rust container to build galry

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,31 @@
+# Do a multistage build.
+# Build galry in a rust container, and then copy the binary to a plain alpine
+# container
+FROM rust:alpine AS build
+
+# The pear_codegen v0.1.5 library gives this error unless built with nightly:
+# Error: Pear requires a 'dev' or 'nightly' version of rustc.
+# So install nightly build of rust
+RUN rustup install nightly
+
+# This is required by some libraries (like peargen)
+RUN apk add --no-cache musl-dev
+
+# Copy galry sources into build container
+COPY . /app
+WORKDIR /app
+
+# Build galry
+RUN cargo +nightly build --release
+
+# Now copy it into an empty alpine container
+FROM alpine as runtime
+RUN apk add --no-cache dumb-init
+
+COPY --from=build /app/target/release/galry /usr/local/bin/galry
+
+WORKDIR /pictures
+
+EXPOSE 8000
+ENTRYPOINT ["dumb-init", "--"]
+CMD [ "/usr/local/bin/galry", "/pictures" ]

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Galry supports a few command line options, each of which can also be configured 
 
 The latter two options can be useful when serving images from slow media (such as an NFS share or HDDs that spin down). By saving the Thumbnails on an SSD and enabling `-z`, Galry will load the image only once from the slow disks and then grab them from the cache on subsequent requests.  
 
-# Building galry
+# Building galry on local host
 
 You need to have the nightly toolchain installed to build galry:
 
@@ -28,3 +28,19 @@ You need to have the nightly toolchain installed to build galry:
 rustup install nightly
 cargo +nightly build --release
 ```
+
+# Building galry in Docker
+
+To create a galry docker image without needing to have rust installed locally, the ```Dockerfile.build``` will use a mulistage build to build galry in an alpine/rust container and put the result in a plain alpine container ready to run.
+
+```
+docker build -t galry -f Dockerfile.build .
+```
+
+# Running Docker image
+
+```
+docker run --rm -p 8000:8000 -v <path_to_images>:/pictures:ro svedrin/galry
+```
+
+Replace ```svedrin/galry``` with just ```galry``` if you used the ```Dockerfile.build``` to build your own docker image.


### PR DESCRIPTION
This may be useful for someone who finds your repository in the future?

The new Dockerfile.build allows creating a galry image without needing to build galry locally first using rust.

Thanks